### PR TITLE
Make RootData and RootSql extensions public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [7.0.2] - TBD
+### Changed
+- Making `RootDataFolderExtension` and `RootSqlFolderExtension` classes public.
+
 ## [7.0.1] - 2019-10-22
 ### Changed
 - Redeploying Maven Artifacts as 7.0.0 release is not showing up in Maven Central (was released when Sonatype was experiencing issues so release 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [7.0.2] - TBD
 ### Changed
-- Making `RootDataFolderExtension` and `RootSqlFolderExtension` classes public.
+- Made `RootDataFolderExtension` and `RootSqlFolderExtension` classes public.
 
 ## [7.0.1] - 2019-10-22
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>fm.last.commons</groupId>
   <artifactId>lastcommons-test</artifactId>
-  <version>7.1.0-SNAPSHOT</version>
+  <version>7.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>lastcommons-test</name>
   <description>Last.fm common test utilities</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>fm.last.commons</groupId>
   <artifactId>lastcommons-test</artifactId>
-  <version>7.0.2-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>lastcommons-test</name>
   <description>Last.fm common test utilities</description>

--- a/src/main/java/fm/last/commons/test/extensions/RootDataFolderExtension.java
+++ b/src/main/java/fm/last/commons/test/extensions/RootDataFolderExtension.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.Extension;
 
 import fm.last.commons.test.core.DataFolderUtils;
 
-class RootDataFolderExtension extends BaseDataFolder implements Extension {
+public class RootDataFolderExtension extends BaseDataFolder implements Extension {
 
   private File folder;
 

--- a/src/main/java/fm/last/commons/test/extensions/RootSqlFolderExtension.java
+++ b/src/main/java/fm/last/commons/test/extensions/RootSqlFolderExtension.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.Extension;
 
 import fm.last.commons.test.core.DataFolderUtils;
 
-class RootSqlFolderExtension extends BaseDataFolder implements Extension {
+public class RootSqlFolderExtension extends BaseDataFolder implements Extension {
 
   private File folder;
 


### PR DESCRIPTION
Made RootData and RootSql public because that was missed when first adding the extension classes to the project.